### PR TITLE
Zephyr: Minimize writing to settings.json

### DIFF
--- a/src/zephyr.ts
+++ b/src/zephyr.ts
@@ -108,6 +108,10 @@ export function boardConfFile(): vscode.Uri | undefined {
 
 export function setBoard(b: BoardTuple) {
     board = b;
+    if (boardStatus) {
+        boardStatus.text = `$(circuit-board) ${b.board}`;
+    }
+
     kEnv.update();
 }
 
@@ -180,6 +184,7 @@ export async function selectBoard() {
                 return;
             }
 
+            setBoard(selection.board);
             updateBoardConfig(selection.board);
         });
 }
@@ -200,23 +205,13 @@ export async function boardFromName(id: string, uri?: vscode.Uri): Promise<Board
 }
 
 function updateBoardConfig(newBoard: BoardTuple) {
-    if (
-        newBoard.board !== board?.board ||
-        newBoard.arch !== board?.arch ||
-        newBoard.dir !== board?.dir
-    ) {
-        if (boardStatus) {
-            boardStatus.text = `$(circuit-board) ${newBoard.board}`;
-        }
-        setBoard(newBoard);
-        vscode.workspace
-            .getConfiguration('kconfig')
-            .update('zephyr.board', board, vscode.ConfigurationTarget.Workspace)
-            .then(
-                () => console.log(`Stored new board ${newBoard.board}`),
-                (err) => console.error(`Failed storing board ${err}`)
-            );
-    }
+    vscode.workspace
+        .getConfiguration('kconfig')
+        .update('zephyr.board', board, vscode.ConfigurationTarget.Workspace)
+        .then(
+            () => console.log(`Stored new board ${newBoard.board}`),
+            (err) => console.error(`Failed storing board ${err}`)
+    );
 }
 
 export function getModules() {

--- a/src/zephyr.ts
+++ b/src/zephyr.ts
@@ -108,7 +108,6 @@ export function boardConfFile(): vscode.Uri | undefined {
 
 export function setBoard(b: BoardTuple) {
     board = b;
-    kEnv.setConfig('zephyr.board', b);
     kEnv.update();
 }
 
@@ -364,7 +363,6 @@ function getZephyrBase(): string | undefined {
 export async function setZephyrBase(uri: vscode.Uri): Promise<void> {
     if (uri.fsPath !== zephyrRoot) {
         zephyrRoot = uri.fsPath;
-        await kEnv.setConfig('zephyr.base', zephyrRoot);
     }
 }
 
@@ -456,7 +454,6 @@ export async function setWest(westUri: string, env?: typeof process.env): Promis
 
     if (westUri !== westExe) {
         westExe = westUri;
-        await kEnv.setConfig('zephyr.west', westExe);
     }
 }
 

--- a/src/zephyr.ts
+++ b/src/zephyr.ts
@@ -211,7 +211,7 @@ function updateBoardConfig(newBoard: BoardTuple) {
         .then(
             () => console.log(`Stored new board ${newBoard.board}`),
             (err) => console.error(`Failed storing board ${err}`)
-    );
+        );
 }
 
 export function getModules() {


### PR DESCRIPTION
Removes all redundant writes to the workspace settings. This resolves
issues with variables being automatically expanded in the settings upon
extension activation, and prevents the extension from creating a
settings file in every workspace it's activated in.

The settings file should be treated as a way for the user to configure
the application, not as a persistent storage mechanism.