### PR TITLE
Support uncommon env var format in kconfig files

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -41,7 +41,7 @@ function replace(text: string, map: Record<string, string | undefined>): string 
             return env[v.slice('env:'.length)] ?? '';
         }
 
-        if (v === vars[2]) {
+        if (v in env) {
             return env[v] ?? '';
         }
 


### PR DESCRIPTION
Ensures that environment variables can be referred to in all three
formats permitted by kconfiglib:
- $(VARIABLE)
- ${VARIABLE}
- $VARIABLE