### PR TITLE
Reduce LSP file events

### DIFF
--- a/src/langHandler.ts
+++ b/src/langHandler.ts
@@ -23,6 +23,7 @@ export class KconfigLangHandler
     files: ParsedFile[];
     configured = false;
     rescanTimer?: NodeJS.Timeout;
+    nameResolved = new Set<string>();
     constructor() {
         const sortItems = (item: vscode.CompletionItem, i: number) => {
             const pad = '0000';
@@ -87,11 +88,17 @@ export class KconfigLangHandler
          * files at all. Set the kconfig language through a fallback for files
          * that have no other file type set instead:
          */
-        if (!d.languageId || d.languageId === 'plaintext') {
+        if (
+            d.uri.scheme === 'file' &&
+            (!d.languageId || d.languageId === 'plaintext') &&
+            !this.nameResolved.has(d.uri.toString())
+        ) {
             if (path.basename(d.fileName).startsWith('Kconfig.')) {
                 vscode.languages.setTextDocumentLanguage(d, 'kconfig');
+                this.nameResolved.add(d.uri.toString());
             } else if (path.basename(d.fileName).endsWith('_defconfig')) {
                 vscode.languages.setTextDocumentLanguage(d, 'properties');
+                this.nameResolved.add(d.uri.toString());
             }
         }
     }

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -39,12 +39,15 @@ function startServer(ctx: vscode.ExtensionContext) {
             },
             {
                 language: 'c',
+                scheme: 'file',
             },
             {
                 language: 'cpp',
+                scheme: 'file',
             },
             {
                 language: 'kconfig',
+                scheme: 'file',
             },
         ],
 


### PR DESCRIPTION
The language server gets a lot more file synchronization events from the
extension host than required, due to two issues in the file handling on
the host side:
- The langHandler class dynamically changes the language mode for
  plaintext files with specific names to kconfig, making them reload. If
  some other service actively does the same thing, they can end up
  competing, causing an infinite loop of reloads. Cache the URIs of the
  updated files, so we only do this once per file per session.
- The Git extension sometimes posts endless updates to its virtual
  representation of the index. These are always in the 'git' scheme, so
  adding a scheme qualifier to the set of synchronized files prevents
  this from going to the language server.