### PR TITLE
Treat IO as byte stream 

### DIFF
--- a/srv/test/mock_stream.py
+++ b/srv/test/mock_stream.py
@@ -12,8 +12,8 @@ class StreamEnd(Exception):
 
 class MockStream:
     def __init__(self):
-        self.input = ''
-        self.output = ''
+        self.input = b''
+        self.output = b''
 
     def read(self, n=-1):
         if len(self.input) < n:
@@ -21,7 +21,7 @@ class MockStream:
 
         if n == -1:
             retval = self.input
-            self.input = ''
+            self.input = b''
         else:
             retval = self.input[:n]
             self.input = self.input[n:]
@@ -29,18 +29,18 @@ class MockStream:
 
     def readline(self):
         try:
-            idx = self.input.index('\n')
+            idx = self.input.index(b'\n')
         except ValueError as e:
             raise StreamEnd()
         val = self.read(idx + 1)
         sys.stdout.write(f'Reading line as {idx} bytes: "{val}"\n')
         return val
 
-    def write(self, buf):
+    def write(self, buf: bytes):
         self.output += buf
 
-    def push(self, buf):
-        self.input += buf
+    def push(self, buf: str, encoding='utf-8'):
+        self.input += buf.encode(encoding)
 
     def flush(self):
         pass
@@ -48,15 +48,15 @@ class MockStream:
     def pull(self, n=-1):
         if n == -1 or n > len(self.output):
             retval = self.output
-            self.output = ''
+            self.output = b''
         else:
             retval = self.output[:n]
             self.output = self.output[n:]
-        return retval
+        return retval.decode('utf-8')
 
     def pull_line(self):
         try:
-            idx = self.output.index('\n')
+            idx = self.output.index(b'\n')
         except ValueError as e:
             raise StreamEnd()
         return self.pull(idx + 1)

--- a/srv/test/test_kconfiglsp.py
+++ b/srv/test/test_kconfiglsp.py
@@ -48,7 +48,7 @@ def recv(count=10) -> List[RPCResponse]:
 
 def request(name, params=None):
     global req_id
-    io.output = ''  # flush
+    io.output = b''  # flush
     req_id += 1
     req = RPCRequest(req_id, name, params)
     srv.handle(req)


### PR DESCRIPTION
The RPC header's Content-Length field designates the number of bytes in
the contents, not the number of characters. As the content is utf-8
encoded, this might not always be the same number.

Use sys.stdin.buffer and sys.stdout.buffer as default streams to ensure
that the incoming data is a raw buffer, and not a decoded string,
allowing us to pull an exact number of bytes from the stream instead of
an exact number of characters. Perform decoding manually and according
to spec.

Added test coverage.